### PR TITLE
add support for blocks have a space

### DIFF
--- a/server/src/mindustry/server/EmojiFilter.java
+++ b/server/src/mindustry/server/EmojiFilter.java
@@ -55,7 +55,12 @@ public class EmojiFilter implements ApplicationListener{
             }
 
             for(String word : text.split("\\s+")){
-                word = word.replaceAll("\\p{Punct}", "");
+                if (word.startsWith("#")) {
+                    text = text.replaceAll("(?i)" + word, word.replaceAll("#", ""));
+                    continue;
+                }
+
+                word = word.replaceAll("[\\p{Punct}&&[^-]]+", "");
                 if(Fonts.getUnicode(word.toLowerCase()) != 0 && !blacklist.contains(word)){
                     text = text.replaceAll("(?i)" + word, (char) Fonts.getUnicode(word.toLowerCase()) + "");
                 }


### PR DESCRIPTION
stuff like core-nucleus should work
adding # before the block name makes the filter ignore it